### PR TITLE
Factored logic out of smoke-tests into utils crate, some of it feature gated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,10 @@ serde_json = "*"
 derive_more = "*"
 base64 = "*"
 eyre = "*"
-dirs = "*"
+dirs = { version = "*", optional = true }
+
+[dev-dependencies]
+cfg-if = "0.1.10"
+
+[features]
+cookie-finder = ["dirs"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,7 @@
 #[macro_use]
 mod callrpc;
 pub mod subcomponents;
+pub mod utils;
 
 use self::subcomponents::{
     GetBlockChainInfoResponse, GetInfoResponse, ZGetNewAddressResponse,

--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -1,0 +1,35 @@
+#[cfg(feature = "cookie-finder")]
+pub fn get_cookie() -> std::io::Result<String> {
+    let mut cookie_path = match dirs::home_dir() {
+        Some(x) => x,
+        None => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!(
+                    "{} {} {}",
+                    "Could not find your home directory.",
+                    "Please pass the contents of ~/.zcash/.cookie to the",
+                    "enviroment variable ZCASH_TEST_AUTH."
+                ),
+            ))
+        }
+    };
+
+    cookie_path.push(".zcash");
+    if std::env::var("REGTEST").is_ok() {
+        cookie_path.push("regtest");
+    }
+    cookie_path.push(".cookie");
+
+    let mut cookie_file = std::fs::File::open(cookie_path)?;
+    let mut cookie_string = String::new();
+    use std::io::Read as _;
+    cookie_file.read_to_string(&mut cookie_string)?;
+    Ok(cookie_string)
+}
+
+pub fn get_zcashd_port() -> String {
+    //This could theoretically be expanded to do some sort of
+    //automatic port lookup
+    String::from("127.0.0.1:18232")
+}

--- a/tests/zcashrpc-smoke-tests.rs
+++ b/tests/zcashrpc-smoke-tests.rs
@@ -1,8 +1,8 @@
 fn make_client() -> zcashrpc::Client {
     let host = std::env::var("ZCASHRPC_TEST_HOST")
-        .unwrap_or(String::from("127.0.0.1:18232".to_string()));
+        .unwrap_or(zcashrpc::client::utils::get_zcashd_port());
     let auth = std::env::var("ZCASHRPC_TEST_AUTH")
-        .or_else(get_cookie)
+        .or_else(get_cookie_with_env_var_err)
         .expect("cookie lookup failed");
     zcashrpc::Client::new(host, auth)
 }
@@ -19,38 +19,26 @@ run_smoketest!(getinfo);
 run_smoketest!(getblockchaininfo);
 run_smoketest!(z_getnewaddress);
 
-fn get_cookie(error: std::env::VarError) -> std::io::Result<String> {
+fn get_cookie_with_env_var_err(
+    error: std::env::VarError,
+) -> std::io::Result<String> {
     let log_msg = format!(
         "Invalid or no value passed to environment {} {}. {}",
         "variable ZCASHRPC_TEST_AUTH. Details:",
         error,
         "Defaulting to cookie lookup."
     );
-    dbg!(log_msg);
-    let mut cookie_path = match dirs::home_dir() {
-        Some(x) => x,
-        None => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!(
-                    "{} {} {}",
-                    "Could not find your home directory.",
-                    "Please pass the contents of ~/.zcash/.cookie to the",
-                    "enviroment variable ZCASH_TEST_AUTH."
-                ),
-            ))
+    println!("{}", log_msg);
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "cookie-finder")] {
+            zcashrpc::client::utils::get_cookie()
+        } else {
+            let log_msg = format!(
+                "For automatic authentication, run with flag {}",
+                "'--features \"cookie-finder\"'."
+            );
+            panic!(log_msg);
         }
-    };
-
-    cookie_path.push(".zcash");
-    if std::env::var("REGTEST").is_ok() {
-        cookie_path.push("regtest");
     }
-    cookie_path.push(".cookie");
-
-    let mut cookie_file = std::fs::File::open(cookie_path)?;
-    let mut cookie_string = String::new();
-    use std::io::Read as _;
-    cookie_file.read_to_string(&mut cookie_string)?;
-    Ok(cookie_string)
 }


### PR DESCRIPTION
Moved some logic into `zcashrpc::client::utils`. Unfortunately, the file system stuff should be feature-gated as it adds a dependency, and there's no way to make default features specific to tests. Added some conditional logic to the smoke tests to compensate.