### PR TITLE
DRY make client

### DIFF
--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -33,3 +33,7 @@ pub fn get_zcashd_port() -> String {
     //automatic port lookup
     String::from("127.0.0.1:18232")
 }
+
+pub fn make_client(regtest: bool) -> crate::Client {
+    crate::Client::new(get_zcashd_port(), get_cookie(regtest).unwrap())
+}

--- a/zcash-rcli/src/commands.rs
+++ b/zcash-rcli/src/commands.rs
@@ -42,14 +42,6 @@ pub enum ZcashRcliCmd {
     Version(version::VersionCmd),
 }
 
-fn make_client(regtest: bool) -> zcashrpc::Client {
-    use zcashrpc::client::utils;
-    zcashrpc::Client::new(
-        utils::get_zcashd_port(),
-        utils::get_cookie(regtest).unwrap(),
-    )
-}
-
 /// A simple Definition and Runnable implementation for commands that make an
 /// rpc call which takes no arguments
 macro_rules! zero_arg_run_impl {
@@ -64,7 +56,7 @@ macro_rules! zero_arg_run_impl {
             fn run(&self) {
                 abscissa_tokio::run(&$crate::application::APPLICATION, async {
                     let response =
-                        $crate::commands::make_client(true).$rpc_call();
+                        zcashrpc::client::utils::make_client(true).$rpc_call();
                     println!("Help flag: {:?}", self.help);
                     println!("{:?}", response.await);
                 }).unwrap();


### PR DESCRIPTION
In order to avoid code repetition I am factoring logic out of `zcash-rcli` and _into_ `zcashrpc`.

I am just starting a new app `quizface`, and this is a good moment to notice when the functionality in the existing app `zcash-rcli` is what I need.

This pattern of noticing two concrete examples of the same thing, and then abstracting out a single procedure to define it
I am going to invoke this logic "make_client" from my sister abscissa app `quizface`.   

I factored it into `zcashrpc`, and referenced it from there in `zcash-rcli`.

When I implement `quizface` I will also refer to `make_client` in `zcashrpc`, of course this implies that the `zcashrpc` crate is a dependency of both app crates (`quizface` and `zcash-rcli`), but this was already the case, as can be seen by inspecting each crate's manifest file. You won't find any dependency in the crate that's _not_ on the manifest...   so _read the manifest_!

`quizface` will _not_ rely on `zcash-rcli` because it `quizface` is being used to _build_ `zcash-rcli`.

An interesting (and immediate) question is, how do the two tools separate concerns?
Which tool do you use for which task?

Those questions should be fleshed out _while_ construction of the tool is ongoing.   The answers are clearer once more of the tool exists, _but_ the question should be asked now...  before the tool _implementation_ is started, and the question should be _asked aloud_.   Note tool _implementation_ is _not_ the start of tool creation!

By expressing the intention now, and letting my team-mates know about it, I am helping them adapt their designs to mine, which empowers me to adapt my designs theirs.   Clearer more understood designs are mutually empowering.

There's another really key technique here...   copying!   @AloeareV did the more difficult exploratory work of the initial implementation of an abscissa app.   In addition to correctly using the `abscissa` framework, she also discovered another useful tool json_typegen, and has already offered some improvements to it!

https://github.com/evestera/json_typegen/pull/19

Anyway hopping back to `zcash-rcli`, I am copying as much as I can from @AloeareV .