### PR TITLE
change expected simple_terminal output order

### DIFF
--- a/zcashrpc-typegen/test_output/terminal_alias_expected.rs
+++ b/zcashrpc-typegen/test_output/terminal_alias_expected.rs
@@ -1,11 +1,11 @@
 //procedurally generated response types, note that zcashrpc-typegen
 //is in early alpha, and output is subject to change at any time.
-pub mod numberAlias {
-    pub type NumberAliasResponse = rust_decimal::Decimal;
+pub mod boolAlias {
+    pub type BoolAliasResponse = bool;
 }
 pub mod stringAlias {
     pub type StringAliasResponse = String;
 }
-pub mod boolAlias {
-    pub type BoolAliasResponse = bool;
+pub mod numberAlias {
+    pub type NumberAliasResponse = rust_decimal::Decimal;
 }


### PR DESCRIPTION
Why did this order change?